### PR TITLE
[new] applying the event-selection and matching corrections via a matrix multiplication of the histogram and the efficiency factors

### DIFF
--- a/CommonCode/include/EffCorrFactor.h
+++ b/CommonCode/include/EffCorrFactor.h
@@ -28,6 +28,7 @@ public:
 
    // apply the correction factor on the exact histogram binning
    // would just be a multiplication operation
+   void applyEffCorrOnHisto(TH1D* h_1D_bfCorr, TH1D* h_1D_afCorr);
    void applyEffCorrOnHisto(TH2D* h_2D_bfCorr, TH2D* h_2D_afCorr);
 
    // apply the correction factor on an entry-by-entry basis
@@ -85,8 +86,65 @@ void EffCorrFactor::write(TFile& OutputFile, string effArgName, TH2D* _h_num, TH
    _heff_2D->Write();
 }
 
+void EffCorrFactor::applyEffCorrOnHisto(TH1D* h_1D_bfCorr, TH1D* h_1D_afCorr)
+{
+   if (!_heff_1D) 
+   {
+      printf("[Error] EffCorrFactor::applyEffCorrOnHisto couldn't find _heff_1D.\n");
+      _effInf->ls();
+      exit(1);
+   }
+
+   for (Int_t ix=0;ix<=h_1D_bfCorr->GetNbinsX();ix++)
+   { 
+      // checking the bin boundaries 
+      if (h_1D_bfCorr->GetXaxis()->GetBinLowEdge(ix)!=_heff_1D->GetXaxis()->GetBinLowEdge(ix) ||
+          h_1D_bfCorr->GetXaxis()->GetBinLowEdge(ix)!=h_1D_afCorr->GetXaxis()->GetBinLowEdge(ix))
+      {
+         printf("[Error] EffCorrFactor::applyEffCorrOnHisto is doing a matrix multiplication.\n" \
+                "This requires the uncorrected, corrected distributions and the efficiency factor has the same bin configuration!\n");
+         exit(1);
+      }
+
+      double x = h_1D_bfCorr->GetXaxis()->GetBinCenter(ix);
+
+      int hBinIdx    = h_1D_bfCorr->FindBin(x);
+      int effBinIdx  = _heff_1D->FindBin(x);
+      if(_heff_1D->GetBinContent(effBinIdx)>0)
+      {
+         double n_afCorr   = h_1D_bfCorr->GetBinContent(hBinIdx)/_heff_1D->GetBinContent(effBinIdx);
+         double errrel_num = (h_1D_bfCorr->GetBinError(hBinIdx)>0 && h_1D_bfCorr->GetBinContent(hBinIdx)>0)? h_1D_bfCorr->GetBinError(hBinIdx)/h_1D_bfCorr->GetBinContent(hBinIdx): 0;
+         double errrel_den = _heff_1D->GetBinError(effBinIdx)/_heff_1D->GetBinContent(effBinIdx);
+         
+         double errrel_n_afCorr = TMath::Sqrt(errrel_num*errrel_num+errrel_den*errrel_den);
+
+         h_1D_afCorr->SetBinContent(hBinIdx,n_afCorr);
+         h_1D_afCorr->SetBinError  (hBinIdx,n_afCorr*errrel_n_afCorr);
+      }
+      else
+      {
+         h_1D_afCorr->SetBinContent(hBinIdx,0);
+         h_1D_afCorr->SetBinError(hBinIdx,0);
+      }
+      // if (ix<=2)
+      // {
+      //    printf("[ix=%d,x=%.3f] h_1D_bfCorr=%.3f+/-%.3f, _heff_1D=%.3f+/-%.3f, h_1D_afCorr=%.3f+/-%.3f\n", 
+      //             ix, x,
+      //             h_1D_bfCorr->GetBinContent(hBinIdx), h_1D_bfCorr->GetBinError(hBinIdx),
+      //             _heff_1D->GetBinContent(effBinIdx), _heff_1D->GetBinError(effBinIdx),
+      //             h_1D_afCorr->GetBinContent(hBinIdx), h_1D_afCorr->GetBinError(hBinIdx));
+      // }
+   }
+}
+
 void EffCorrFactor::applyEffCorrOnHisto(TH2D* h_2D_bfCorr, TH2D* h_2D_afCorr)
 {
+   if (!_heff_2D) 
+   {
+      printf("[Error] EffCorrFactor::applyEffCorrOnHisto couldn't find _heff_2D.\n");
+      _effInf->ls();
+      exit(1);
+   }
    for (Int_t ix=0;ix<=h_2D_bfCorr->GetNbinsX();ix++)
    { 
       // checking the bin boundaries 
@@ -144,31 +202,45 @@ void EffCorrFactor::applyEffCorrOnHisto(TH2D* h_2D_bfCorr, TH2D* h_2D_afCorr)
 
 Float_t EffCorrFactor::efficiency(Float_t argBin)
 {
-  Float_t e = _heff_1D->GetBinContent(_heff_1D->FindBin(argBin));
-  if(e < 0.00000000001){
-    if(counter < 10){
-      std::cout << "!!!Error on efficiency correction! Zero efficiency!!! " << _heff_1D->GetName() << "=" << argBin << std::endl << std::endl;
-      if(counter == 9) std::cout << " !!!Greater than ten calls of this error... TERMINATING OUTPUT, PLEASE FIX" << std::endl;
-      ++counter;
-    }
-    
+   if (!_heff_1D) 
+   {
+      printf("[Error] EffCorrFactor::applyEffCorrOnHisto couldn't find _heff_1D.\n");
+      _effInf->ls();
+      exit(1);
+   }
+   Float_t e = _heff_1D->GetBinContent(_heff_1D->FindBin(argBin));
+   if(e < 0.00000000001)
+   {
+      if(counter < 10)
+      {
+         std::cout << "!!!Error on efficiency correction! Zero efficiency!!! " << _heff_1D->GetName() << "=" << argBin << std::endl << std::endl;
+         if(counter == 9) std::cout << " !!!Greater than ten calls of this error... TERMINATING OUTPUT, PLEASE FIX" << std::endl;
+         ++counter;
+      }
     e = 1;
-  }  
+   }  
   return e;
 }
 
 Float_t EffCorrFactor::efficiency(Float_t argBin, Float_t normEEBin)
 {
-  Float_t e = _heff_2D->GetBinContent(_heff_2D->FindBin(argBin, normEEBin));
-  if(e < 0.00000000001){
-    if(counter < 10){
-      std::cout << "!!!Error on efficiency correction! Zero efficiency!!! " << _heff_1D->GetName() << "=" << argBin << std::endl << std::endl;
-      if(counter == 9) std::cout << " !!!Greater than ten calls of this error... TERMINATING OUTPUT, PLEASE FIX" << std::endl;
-      ++counter;
-    }
-    
-    e = 1;
-  }  
+   if (!_heff_2D) 
+   {
+      printf("[Error] EffCorrFactor::applyEffCorrOnHisto couldn't find _heff_2D.\n");
+      _effInf->ls();
+      exit(1);
+   }
+   Float_t e = _heff_2D->GetBinContent(_heff_2D->FindBin(argBin, normEEBin));
+   if(e < 0.00000000001)
+   {
+      if(counter < 10)
+      {
+         std::cout << "!!!Error on efficiency correction! Zero efficiency!!! " << _heff_1D->GetName() << "=" << argBin << std::endl << std::endl;
+         if(counter == 9) std::cout << " !!!Greater than ten calls of this error... TERMINATING OUTPUT, PLEASE FIX" << std::endl;
+         ++counter;
+      }
+      e = 1;
+   }  
   return e;
 }
 

--- a/EventSelectionEfficiency/20240922_evtSelEffCorr/evtSelEffCorr.cpp
+++ b/EventSelectionEfficiency/20240922_evtSelEffCorr/evtSelEffCorr.cpp
@@ -76,6 +76,8 @@ int main(int argc, char *argv[])
    double zBinMin = (1- cos(0.002))/2;
    double zBinMax = 0.5;
 
+   // [Warning] A future todo improvement task after HP2024
+   //           to make the bin boundary configurable in the future
    // energy binning
    // const int EnergyBinCount = 10; 
    // double EnergyBins[EnergyBinCount+1];
@@ -96,6 +98,8 @@ int main(int argc, char *argv[])
     
    }
 
+   // [Warning] A future todo improvement task after HP2024
+   //           to make the bin boundary configurable in the future
    // EnergyBins[0] = 0;
    // for(int e = 1; e <= EnergyBinCount; e++){
    //    double logValue = logMin + e * logStep;

--- a/EventSelectionEfficiency/20240922_evtSelEffCorr/evtSelEffCorr.cpp
+++ b/EventSelectionEfficiency/20240922_evtSelEffCorr/evtSelEffCorr.cpp
@@ -78,13 +78,13 @@ int main(int argc, char *argv[])
    double zBinMax = 0.5;
 
    // energy binning
-   const int EnergyBinCount = 10; 
-   double EnergyBins[EnergyBinCount+1];
-   double EnergyBinMin = 4e-6;
-   double EnergyBinMax = 0.2;
-   double logMin = std::log10(EnergyBinMin);
-   double logMax = std::log10(EnergyBinMax);
-   double logStep = (logMax - logMin) / (EnergyBinCount);
+   // const int EnergyBinCount = 10; 
+   // double EnergyBins[EnergyBinCount+1];
+   // double EnergyBinMin = 4e-6;
+   // double EnergyBinMax = 0.2;
+   // double logMin = std::log10(EnergyBinMin);
+   // double logMax = std::log10(EnergyBinMax);
+   // double logStep = (logMax - logMin) / (EnergyBinCount);
 
    for(int i = 0; i <= BinCount; i++){
       // theta double log binning
@@ -97,21 +97,23 @@ int main(int argc, char *argv[])
     
    }
 
-   EnergyBins[0] = 0;
-   for(int e = 1; e <= EnergyBinCount; e++){
-      double logValue = logMin + e * logStep;
-      EnergyBins[e] =  std::pow(10, logValue);
-   }
+   // EnergyBins[0] = 0;
+   // for(int e = 1; e <= EnergyBinCount; e++){
+   //    double logValue = logMin + e * logStep;
+   //    EnergyBins[e] =  std::pow(10, logValue);
+   //    printf("%f ", EnergyBins[e]);
+   // }
+   vector<double> EnergyBins = {0.0, 0.0001, 0.0002, 0.0005, 0.00075, 0.001, 0.00125, 0.0015, 0.00175, 0.002, 0.0025, 0.003, 0.004, 0.01, 0.04, 0.07, 0.15, 0.3};
 
    // -------------------------------------------
    // allocate the histograms
    // -------------------------------------------
 
    // 2D histograms
-   TH2D h2_EvtSelBefore_Theta("h2_EvtSelBefore_Theta", "h2_EvtSelBefore_Theta", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
-   TH2D h2_EvtSelBefore_Z("h2_EvtSelBefore_Z", "h2_EvtSelBefore_Z", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
-   TH2D h2_EvtSel_Theta("h2_EvtSel_Theta", "h2_EvtSel_Theta", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
-   TH2D h2_EvtSel_Z("h2_EvtSel_Z", "h2_EvtSel_Z", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
+   TH2D h2_EvtSelBefore_Theta("h2_EvtSelBefore_Theta", "h2_EvtSelBefore_Theta", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
+   TH2D h2_EvtSelBefore_Z("h2_EvtSelBefore_Z", "h2_EvtSelBefore_Z", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
+   TH2D h2_EvtSel_Theta("h2_EvtSel_Theta", "h2_EvtSel_Theta", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
+   TH2D h2_EvtSel_Z("h2_EvtSel_Z", "h2_EvtSel_Z", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
 
    // 1D histograms
    TH1D h1_EvtSel_Z("h1_EvtSel_Z", "h1_EvtSel_Z", 2 * BinCount, 0, 2 * BinCount); 
@@ -165,7 +167,7 @@ int main(int argc, char *argv[])
 
             // get the proper bins
             int BinThetaGen  = FindBin(GetAngle(Gen1,Gen2), 2 * BinCount, Bins);
-            int BinEnergyGen = FindBin(Gen1[0]*Gen2[0]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
+            // int BinEnergyGen = FindBin(Gen1[0]*Gen2[0]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
             double zGen = (1-cos(GetAngle(Gen1,Gen2)))/2; 
             int BinZGen = FindBin(zGen, 2*BinCount, zBins); 
 
@@ -173,14 +175,14 @@ int main(int argc, char *argv[])
             double EEC =  Gen1[0]*Gen2[0]/(TotalE*TotalE); 
             
             // fill the histograms
-            h2_EvtSel_Theta.Fill(BinThetaGen, BinEnergyGen, EEC); 
-            h2_EvtSel_Z.Fill(BinZGen, BinEnergyGen, EEC); 
+            h2_EvtSel_Theta.Fill(BinThetaGen, EEC, EEC); 
+            h2_EvtSel_Z.Fill(BinZGen, EEC, EEC); 
             h1_EvtSel_Z.Fill(BinZGen, EEC); 
             h1_EvtSel_Theta.Fill(BinThetaGen, EEC);
             if (!MakeEvtSelEffCorrFactor)
             {
                double efficiency = EvtSelEffCorrFactor.efficiency((EvtSelEffArgName=="z")? BinZGen: BinThetaGen,
-                                                                    BinEnergyGen);
+                                                                    EEC);
                // printf("argBin: %d, z: %.3f, eff: %.3f \n", BinZGen, zGen, efficiency);
                // printf("argBin: %d, normEEBin:%d, z: %.3f, normEE: %.3f, eff: %.3f \n", BinZGen, BinEnergyGen, zGen, EEC, efficiency);
                h1_EvtSelCorrected_Z.Fill(BinZGen, EEC/efficiency); 
@@ -214,7 +216,7 @@ int main(int argc, char *argv[])
 
             // get the proper bins
             int BinThetaGen  = FindBin(GetAngle(Gen1,Gen2), 2 * BinCount, Bins);
-            int BinEnergyGen = FindBin(Gen1[0]*Gen2[0]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
+            // int BinEnergyGen = FindBin(Gen1[0]*Gen2[0]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
             double zGen = (1-cos(GetAngle(Gen1,Gen2)))/2; 
             int BinZGen = FindBin(zGen, 2*BinCount, zBins); 
 
@@ -222,8 +224,8 @@ int main(int argc, char *argv[])
             double EEC =  Gen1[0]*Gen2[0]/(TotalE*TotalE); 
             
             // fill the histograms
-            h2_EvtSelBefore_Theta.Fill(BinThetaGen, BinEnergyGen, EEC); 
-            h2_EvtSelBefore_Z.Fill(BinZGen, BinEnergyGen, EEC); 
+            h2_EvtSelBefore_Theta.Fill(BinThetaGen, EEC, EEC); 
+            h2_EvtSelBefore_Z.Fill(BinZGen, EEC, EEC); 
             h1_EvtSelBefore_Z.Fill(BinZGen, EEC); 
             h1_EvtSelBefore_Theta.Fill(BinThetaGen, EEC);
          }

--- a/MainAnalysis/20240922_Correction/Correction.cpp
+++ b/MainAnalysis/20240922_Correction/Correction.cpp
@@ -98,9 +98,20 @@ int main(int argc, char *argv[])
    TH1D* HDataAfCorr1D = (TH1D*) HDataAfCorr.ProjectionX();
    projection(&HDataBfCorr, HDataBfCorr1D);
    projection(&HDataAfCorr, HDataAfCorr1D);
+   Output.cd();
    HDataBfCorr1D->Write();
    HDataAfCorr1D->Write();
-   
+
+   TH1D* HDataBfCorr1D_unfoldBinCorr = (TH1D*) HDataBfCorr1D->Clone(Form("%s_unfoldBinCorr", HDataBfCorr1D->GetName()));
+   TH1D* HDataAfCorr1D_unfoldBinCorr = (TH1D*) HDataAfCorr1D->Clone(Form("%s_unfoldBinCorr", HDataAfCorr1D->GetName()));
+   EffCorrFactor UnfoldingBinCorrFactor;
+   UnfoldingBinCorrFactor.init("../../Unfolding/20240923_UnfoldingBinningCorrection/UnfoldingBinCorr_with_z.root", "z");
+   UnfoldingBinCorrFactor.applyEffCorrOnHisto(HDataBfCorr1D, HDataBfCorr1D_unfoldBinCorr);
+   UnfoldingBinCorrFactor.applyEffCorrOnHisto(HDataAfCorr1D, HDataAfCorr1D_unfoldBinCorr);
+   Output.cd();
+   HDataBfCorr1D_unfoldBinCorr->Write();
+   HDataAfCorr1D_unfoldBinCorr->Write();
+
    Output.Close();
 
 }

--- a/MainAnalysis/20240922_Correction/Correction.cpp
+++ b/MainAnalysis/20240922_Correction/Correction.cpp
@@ -1,0 +1,106 @@
+#include <iostream>
+#include <vector>
+#include <map>
+using namespace std;
+
+// root includes
+#include "TTree.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TTreeReader.h"
+#include "TTreeReaderValue.h"
+#include "TTreeReaderArray.h"
+#include "TStyle.h"
+#include "TH1D.h"
+#include "TGraphErrors.h"
+#include "TCanvas.h"
+#include "TGraph.h"
+#include "TGaxis.h"
+#include "TLatex.h"
+#include "TLegend.h"
+#include "TMath.h"
+
+#include "Messenger.h"
+#include "CommandLine.h"
+#include "ProgressBar.h"
+#include "TauHelperFunctions3.h"
+#include "SetStyle.h"
+#include "EffCorrFactor.h"
+
+
+
+int main(int argc, char *argv[]);
+int FindBin(double Value, int NBins, double Bins[]); 
+void MakeCanvasZ(vector<TH1D > Histograms, TGraphErrors DataSyst, vector<string> Labels, string Output, string X, string Y, double WorldMin, double WorldMax, bool DoRatio, bool LogX); 
+void MakeCanvas(vector<TH1D> Histograms, TGraphErrors DataSyst, vector<string> Labels, string Output, string X, string Y, double WorldMin, double WorldMax, bool DoRatio, bool LogX); 
+void SetPad(TPad &P); 
+void DivideByBin(TH1D &H, double Bins[]); 
+
+// can we put this in the CommonCode/ ?
+void FillChain(TChain &chain, const vector<string> &files) {
+  for (auto file : files) {
+    chain.Add(file.c_str());
+  }
+}
+
+// JC: the projection is copied here just so a quick check of the projected 1D histogram is accessible
+void projection(TH2D* h_2D, TH1D* h_1D)
+{
+   h_1D->Reset(); 
+   for (int i = 1; i <= h_2D->GetNbinsX(); ++i) {
+      double weight = 0;
+      double error = 0; 
+      for (int j = 1; j <= h_2D->GetNbinsY(); ++j) {
+         double binContent = h_2D->GetBinContent(i, j);
+         double binError= h_2D->GetBinError(i,j);
+         double binCenter = h_2D->GetYaxis()->GetBinCenter(j);
+         weight += binContent*((binCenter));
+         error += pow(binError*binCenter, 2);;
+
+      }
+      h_1D->SetBinContent(i, weight);
+      h_1D->SetBinError(i, sqrt(error));
+   }
+}
+
+int main(int argc, char *argv[])
+{
+   CommandLine CL(argc, argv);
+
+   SetThesisStyle();
+   static vector<int> Colors = GetCVDColors6();
+
+   string InputDataPath          = CL.Get("InputData");
+   string HistoName              = CL.Get("HistoName", "Bayesian_Unfoldediter3_Z");
+   string OutputFileName         = CL.Get("Output", "CorrectedData.root");
+
+   TFile InputData(InputDataPath.c_str(), "READ");
+   TH2D HDataBfCorr( *((TH2D*) InputData.Get(HistoName.c_str())) );
+   TH2D HDataAfCorr( *((TH2D*) HDataBfCorr.Clone(Form("%s_afCorr", HistoName.c_str()))) );
+
+   // HDataBfCorr.Print("all");
+
+   EffCorrFactor matchingEffCorrFactor;
+   matchingEffCorrFactor.init("../../Unfolding/20240328_Unfolding/matchingScheme2/MatchingEff.root", "z");
+   matchingEffCorrFactor.applyEffCorrOnHisto(&HDataBfCorr, &HDataAfCorr);
+
+   EffCorrFactor EvtSelEffCorrFactor;
+   EvtSelEffCorrFactor.init("../../EventSelectionEfficiency/20240922_evtSelEffCorr/EvtSelEff.root", "z");
+   EvtSelEffCorrFactor.applyEffCorrOnHisto(&HDataBfCorr, &HDataAfCorr);
+
+   TFile Output(OutputFileName.c_str(), "RECREATE");
+   Output.cd();
+   HDataBfCorr.Write();
+   HDataAfCorr.Write();
+
+   // JC: the projection is copied here just so a quick check of the projected 1D histogram is accessible
+   TH1D* HDataBfCorr1D = (TH1D*) HDataBfCorr.ProjectionX();
+   TH1D* HDataAfCorr1D = (TH1D*) HDataAfCorr.ProjectionX();
+   projection(&HDataBfCorr, HDataBfCorr1D);
+   projection(&HDataAfCorr, HDataAfCorr1D);
+   HDataBfCorr1D->Write();
+   HDataAfCorr1D->Write();
+   
+   Output.Close();
+
+}

--- a/MainAnalysis/20240922_Correction/makefile
+++ b/MainAnalysis/20240922_Correction/makefile
@@ -1,0 +1,11 @@
+
+
+default: TestRun
+
+TestRun: Execute
+	./Execute --InputData /data/hbossi/PhysicsEEJetEEC/Unfolding/20240922_UnfoldingThetaZ/unfoldingE2C_DoubleLogBinning_FrozenMCBinning_09232024.root
+
+Execute: Correction.cpp
+	g++ Correction.cpp -o Execute `root-config --cflags --libs` \
+		-I$(ProjectBase)/CommonCode/include \
+		$(ProjectBase)/CommonCode/library/*.o

--- a/Unfolding/20240328_Unfolding/matchingEffCorr.cpp
+++ b/Unfolding/20240328_Unfolding/matchingEffCorr.cpp
@@ -102,13 +102,13 @@ int main(int argc, char *argv[])
    double zBinMax = 0.5;
 
    // energy binning
-   const int EnergyBinCount = 10; 
-   double EnergyBins[EnergyBinCount+1];
-   double EnergyBinMin = 4e-6;
-   double EnergyBinMax = 0.2;
-   double logMin = std::log10(EnergyBinMin);
-   double logMax = std::log10(EnergyBinMax);
-   double logStep = (logMax - logMin) / (EnergyBinCount);
+   // const int EnergyBinCount = 10; 
+   // double EnergyBins[EnergyBinCount+1];
+   // double EnergyBinMin = 4e-6;
+   // double EnergyBinMax = 0.2;
+   // double logMin = std::log10(EnergyBinMin);
+   // double logMax = std::log10(EnergyBinMax);
+   // double logStep = (logMax - logMin) / (EnergyBinCount);
 
    for(int i = 0; i <= BinCount; i++){
       // theta double log binning
@@ -121,21 +121,22 @@ int main(int argc, char *argv[])
     
    }
 
-   EnergyBins[0] = 0;
-   for(int e = 1; e <= EnergyBinCount; e++){
-      double logValue = logMin + e * logStep;
-      EnergyBins[e] =  std::pow(10, logValue);
-   }
+   // EnergyBins[0] = 0;
+   // for(int e = 1; e <= EnergyBinCount; e++){
+   //    double logValue = logMin + e * logStep;
+   //    EnergyBins[e] =  std::pow(10, logValue);
+   // }
+   vector<double> EnergyBins = {0.0, 0.0001, 0.0002, 0.0005, 0.00075, 0.001, 0.00125, 0.0015, 0.00175, 0.002, 0.0025, 0.003, 0.004, 0.01, 0.04, 0.07, 0.15, 0.3};
 
    // -------------------------------------------
    // allocate the histograms
    // -------------------------------------------
 
    // 2D histograms
-   TH2D h2_BeforeMatching_Theta("h2_BeforeMatching_Theta", "h2_BeforeMatching_Theta", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
-   TH2D h2_BeforeMatching_Z("h2_BeforeMatching_Z", "h2_BeforeMatching_Z", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
-   TH2D h2_Matching_Theta("h2_Matching_Theta", "h2_Matching_Theta", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
-   TH2D h2_Matching_Z("h2_Matching_Z", "h2_Matching_Z", 2 * BinCount, 0, 2 * BinCount,  EnergyBinCount, EnergyBins);
+   TH2D h2_BeforeMatching_Theta("h2_BeforeMatching_Theta", "h2_BeforeMatching_Theta", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
+   TH2D h2_BeforeMatching_Z("h2_BeforeMatching_Z", "h2_BeforeMatching_Z", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
+   TH2D h2_Matching_Theta("h2_Matching_Theta", "h2_Matching_Theta", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
+   TH2D h2_Matching_Z("h2_Matching_Z", "h2_Matching_Z", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
 
    // 1D histograms
    TH1D h1_Matching_Z("h1_Matching_Z", "h1_Matching_Z", 2 * BinCount, 0, 2 * BinCount); 
@@ -174,7 +175,7 @@ int main(int argc, char *argv[])
       {
          // get the proper bins
          int BinThetaGen  = FindBin(Matched_DistanceGen[iPair], 2 * BinCount, Bins);
-         int BinEnergyGen = FindBin(Matched_E1E2Gen[iPair], EnergyBinCount, EnergyBins);
+         // int BinEnergyGen = FindBin(Matched_E1E2Gen[iPair], EnergyBinCount, EnergyBins);
          double zGen = (1-cos(Matched_DistanceGen[iPair]))/2; 
          int BinZGen = FindBin(zGen, 2*BinCount, zBins); 
 
@@ -182,14 +183,14 @@ int main(int argc, char *argv[])
          double EEC =  Matched_E1E2Gen[iPair]; 
          
          // fill the histograms
-         h2_Matching_Theta.Fill(BinThetaGen, BinEnergyGen, EEC); 
-         h2_Matching_Z.Fill(BinZGen, BinEnergyGen, EEC); 
+         h2_Matching_Theta.Fill(BinThetaGen, EEC, EEC); 
+         h2_Matching_Z.Fill(BinZGen, EEC, EEC); 
          h1_Matching_Z.Fill(BinZGen, EEC); 
          h1_Matching_Theta.Fill(BinThetaGen, EEC);
          if (!MakeMatchingEffCorrFactor)
          {
             double efficiency = matchingEffCorrFactor.efficiency((MatchingEffArgName=="z")? BinZGen: BinThetaGen,
-                                                                 BinEnergyGen);
+                                                                 EEC);
             // printf("argBin: %d, z: %.3f, eff: %.3f \n", BinZGen, zGen, efficiency);
             // printf("argBin: %d, normEEBin:%d, z: %.3f, normEE: %.3f, eff: %.3f \n", BinZGen, BinEnergyGen, zGen, EEC, efficiency);
             h1_MatchingCorrected_Z.Fill(BinZGen, EEC/efficiency); 
@@ -211,7 +212,7 @@ int main(int argc, char *argv[])
       {
          // get the proper bins
          int BinThetaGen  = FindBin(DistanceUnmatchedGen[iPair], 2 * BinCount, Bins);
-         int BinEnergyGen = FindBin(E1E2GenUnmatched[iPair]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
+         // int BinEnergyGen = FindBin(E1E2GenUnmatched[iPair]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
          double zGen = (1-cos(DistanceUnmatchedGen[iPair]))/2; 
          int BinZGen = FindBin(zGen, 2*BinCount, zBins); 
 
@@ -219,8 +220,8 @@ int main(int argc, char *argv[])
          double EEC =  E1E2GenUnmatched[iPair]/(TotalE*TotalE); 
          
          // fill the histograms
-         h2_BeforeMatching_Theta.Fill(BinThetaGen, BinEnergyGen, EEC); 
-         h2_BeforeMatching_Z.Fill(BinZGen, BinEnergyGen, EEC); 
+         h2_BeforeMatching_Theta.Fill(BinThetaGen, EEC, EEC); 
+         h2_BeforeMatching_Z.Fill(BinZGen, EEC, EEC); 
          h1_BeforeMatching_Z.Fill(BinZGen, EEC); 
          h1_BeforeMatching_Theta.Fill(BinThetaGen, EEC);
       }

--- a/Unfolding/20240328_Unfolding/matchingEffCorr.cpp
+++ b/Unfolding/20240328_Unfolding/matchingEffCorr.cpp
@@ -101,6 +101,8 @@ int main(int argc, char *argv[])
    double zBinMin = (1- cos(0.002))/2;
    double zBinMax = 0.5;
 
+   // [Warning] A future todo improvement task after HP2024
+   //           to make the bin boundary configurable in the future
    // energy binning
    // const int EnergyBinCount = 10; 
    // double EnergyBins[EnergyBinCount+1];
@@ -121,6 +123,8 @@ int main(int argc, char *argv[])
     
    }
 
+   // [Warning] A future todo improvement task after HP2024
+   //           to make the bin boundary configurable in the future
    // EnergyBins[0] = 0;
    // for(int e = 1; e <= EnergyBinCount; e++){
    //    double logValue = logMin + e * logStep;

--- a/Unfolding/20240923_UnfoldingBinningCorrection/makefile
+++ b/Unfolding/20240923_UnfoldingBinningCorrection/makefile
@@ -1,0 +1,21 @@
+default: TestRun
+
+TestRun: Execute
+	./Execute --Input /data/hbossi/PhysicsEEJetEEC/Unfolding/20240922_UnfoldingThetaZ/unfoldingE2C_DoubleLogBinning_FrozenBinning_v2_09232024.root \
+			     --UnfoldingBinCorrName UnfoldingBinCorr_with_z.root \
+			     --UnfoldingBinCorrArgName z --MakeUnfoldingBinCorrFactor true
+	./Execute --Input /data/hbossi/PhysicsEEJetEEC/Unfolding/20240922_UnfoldingThetaZ/unfoldingE2C_DoubleLogBinning_FrozenBinning_v2_09232024.root \
+			     --UnfoldingBinCorrName UnfoldingBinCorr_with_z.root \
+			     --UnfoldingBinCorrArgName z
+	./Execute --Input /data/hbossi/PhysicsEEJetEEC/Unfolding/20240922_UnfoldingThetaZ/unfoldingE2C_DoubleLogBinning_FrozenBinning_v2_09232024.root \
+			     --UnfoldingBinCorrName UnfoldingBinCorr_with_theta.root \
+			     --UnfoldingBinCorrArgName theta --MakeUnfoldingBinCorrFactor true
+	./Execute --Input /data/hbossi/PhysicsEEJetEEC/Unfolding/20240922_UnfoldingThetaZ/unfoldingE2C_DoubleLogBinning_FrozenBinning_v2_09232024.root \
+			     --UnfoldingBinCorrName UnfoldingBinCorr_with_theta.root \
+			     --UnfoldingBinCorrArgName theta
+
+Execute: unfoldingBinningCorrection.cpp
+	g++ unfoldingBinningCorrection.cpp -o Execute \
+		`root-config --glibs --cflags` \
+		-I$(ProjectBase)/CommonCode/include \
+		$(ProjectBase)/CommonCode/library/*.o

--- a/Unfolding/20240923_UnfoldingBinningCorrection/unfoldingBinningCorrection.cpp
+++ b/Unfolding/20240923_UnfoldingBinningCorrection/unfoldingBinningCorrection.cpp
@@ -88,8 +88,15 @@ int main(int argc, char *argv[])
 
    if (!MakeUnfoldingBinCorrFactor)
    {
-      UnfoldingBinCorrFactor.applyEffCorrOnHisto( &h1_Projected2DUnfolding_Z, &h1_UnfoldingBinReweighted_Z );
-      UnfoldingBinCorrFactor.applyEffCorrOnHisto( &h1_Projected2DUnfolding_Theta, &h1_UnfoldingBinReweighted_Theta );
+      int applyEffCorrOnHistoErrorStatus = 0;
+      applyEffCorrOnHistoErrorStatus += UnfoldingBinCorrFactor.applyEffCorrOnHisto( &h1_Projected2DUnfolding_Z, &h1_UnfoldingBinReweighted_Z );
+      applyEffCorrOnHistoErrorStatus += UnfoldingBinCorrFactor.applyEffCorrOnHisto( &h1_Projected2DUnfolding_Theta, &h1_UnfoldingBinReweighted_Theta );
+      
+      if (applyEffCorrOnHistoErrorStatus>0)
+      {
+         printf("[Error] Something wrong with applyEffCorrOnHisto.\n");
+         return 1;
+      }
    }
 
    //------------------------------------

--- a/Unfolding/20240923_UnfoldingBinningCorrection/unfoldingBinningCorrection.cpp
+++ b/Unfolding/20240923_UnfoldingBinningCorrection/unfoldingBinningCorrection.cpp
@@ -1,4 +1,4 @@
-// ./EvtSelEffCorr.exe --Input v0/LEP1MC1994_recons_aftercut-001_Matched.root --Matched PairTree --Unmatched UnmatchedPairTree
+// ./UnfoldingBinCorr.exe --Input v0/LEP1MC1994_recons_aftercut-001_Matched.root --Matched PairTree --Unmatched UnmatchedPairTree
 #include <iostream>
 #include <vector>
 #include <map>
@@ -48,23 +48,53 @@ int main(int argc, char *argv[])
    SetThesisStyle();
    static vector<int> Colors = GetCVDColors6();
 
-   string InputFileName          = CL.Get("Input");
-   string EvtSelEffFileName      = CL.Get("EvtSelEffName", "EvtSelEff.root");
-   string EvtSelEffArgName       = CL.Get("EvtSelEffArgName", "z");
-   bool MakeEvtSelEffCorrFactor  = CL.GetBool("MakeEvtSelEffCorrFactor", false);
-   string GenTreeName            = CL.Get("Gen", "tgen");
-   string GenBeforeTreeName      = CL.Get("GenBefore", "tgenBefore");
+   string InputFileName                = CL.Get("Input");
+   string UnfoldingBinCorrFileName     = CL.Get("UnfoldingBinCorrName", "UnfoldingBinCorr.root");
+   string UnfoldingBinCorrArgName      = CL.Get("UnfoldingBinCorrArgName", "z"); // theta
+   bool MakeUnfoldingBinCorrFactor     = CL.GetBool("MakeUnfoldingBinCorrFactor", false);
    TFile InputFile(InputFileName.c_str());
 
-   double TotalE = 91.1876;
+   string Projected2DUnfoldingName     =  (UnfoldingBinCorrArgName=="theta")? "h1True_Theta_ProjectionX":
+                                          "h1True_Z_ProjectionX";
+   string MCGen1DName                  =  (UnfoldingBinCorrArgName=="theta")? "h1MCGen_Theta":
+                                          "h1MCGen_Z";
 
-   ParticleTreeMessenger MGen(InputFile, GenTreeName);
-   ParticleTreeMessenger MGenBefore(InputFile, GenBeforeTreeName); 
+   // -------------------------------------------
+   // allocate the histograms
+   // -------------------------------------------
+   // 1D histograms
+   TH1D h1_Projected2DUnfolding_Z( *((TH1D*) InputFile.Get("h1True_Theta_ProjectionX")) );
+   TH1D h1_MCGen1D_Z( *((TH1D*) InputFile.Get("h1MCGen_Z")) );
+   TH1D h1_Projected2DUnfolding_Theta( *((TH1D*) InputFile.Get("h1True_Theta_ProjectionX")) );
+   TH1D h1_MCGen1D_Theta( *((TH1D*) InputFile.Get("h1MCGen_Theta")) );
+
+   // reweighted 1D histograms
+   TH1D h1_UnfoldingBinReweighted_Z( *((TH1D*) h1_Projected2DUnfolding_Z.Clone(Form("%s_afCorr", h1_Projected2DUnfolding_Z.GetName()))) );
+   TH1D h1_UnfoldingBinReweighted_Theta( *((TH1D*) h1_Projected2DUnfolding_Theta.Clone(Form("%s_afCorr", h1_Projected2DUnfolding_Theta.GetName()))) );
 
    //------------------------------------
-   // define the binning
+   // define the unfolding binning correction factor
    //------------------------------------
+   EffCorrFactor UnfoldingBinCorrFactor;
+   if (!filesystem::exists(UnfoldingBinCorrFileName.c_str())) MakeUnfoldingBinCorrFactor = true;
+   
+   if (MakeUnfoldingBinCorrFactor)
+   {
+      printf("[INFO] produce unfolding binning correction factor (%s), UnfoldingBinCorrArgName=%s\n", UnfoldingBinCorrFileName.c_str(), UnfoldingBinCorrArgName.c_str());
+   } else {
+      printf("[INFO] applying unfolding binning correction factor (%s), UnfoldingBinCorrArgName=%s\n", UnfoldingBinCorrFileName.c_str(), UnfoldingBinCorrArgName.c_str());
+      UnfoldingBinCorrFactor.init(UnfoldingBinCorrFileName.c_str(), UnfoldingBinCorrArgName.c_str());
+   }
 
+   if (!MakeUnfoldingBinCorrFactor)
+   {
+      UnfoldingBinCorrFactor.applyEffCorrOnHisto( &h1_Projected2DUnfolding_Z, &h1_UnfoldingBinReweighted_Z );
+      UnfoldingBinCorrFactor.applyEffCorrOnHisto( &h1_Projected2DUnfolding_Theta, &h1_UnfoldingBinReweighted_Theta );
+   }
+
+   //------------------------------------
+   // define the binning from histograms
+   //------------------------------------
    // theta binning
    const int BinCount = 100;
    double Bins[2*BinCount+1];
@@ -75,15 +105,6 @@ int main(int argc, char *argv[])
    double zBins[2*BinCount+1];
    double zBinMin = (1- cos(0.002))/2;
    double zBinMax = 0.5;
-
-   // energy binning
-   // const int EnergyBinCount = 10; 
-   // double EnergyBins[EnergyBinCount+1];
-   // double EnergyBinMin = 4e-6;
-   // double EnergyBinMax = 0.2;
-   // double logMin = std::log10(EnergyBinMin);
-   // double logMax = std::log10(EnergyBinMax);
-   // double logStep = (logMax - logMin) / (EnergyBinCount);
 
    for(int i = 0; i <= BinCount; i++){
       // theta double log binning
@@ -96,236 +117,97 @@ int main(int argc, char *argv[])
     
    }
 
-   // EnergyBins[0] = 0;
-   // for(int e = 1; e <= EnergyBinCount; e++){
-   //    double logValue = logMin + e * logStep;
-   //    EnergyBins[e] =  std::pow(10, logValue);
-   //    printf("%f ", EnergyBins[e]);
-   // }
-   vector<double> EnergyBins = {0.0, 0.0001, 0.0002, 0.0005, 0.00075, 0.001, 0.00125, 0.0015, 0.00175, 0.002, 0.0025, 0.003, 0.004, 0.01, 0.04, 0.07, 0.15, 0.3};
+  TString fnamemc = "/data/janicechen/PhysicsEEJetEEC/Unfolding/20240328_Unfolding/v2/LEP1MC1994_recons_aftercut-001_Matched.root";
+  TFile *inputmc =TFile::Open(fnamemc);
+  TTree *mc=(TTree*)inputmc->Get("PairTree"); 
+  double nEv2=mc->GetEntries();
 
-   // -------------------------------------------
-   // allocate the histograms
-   // -------------------------------------------
-
-   // 2D histograms
-   TH2D h2_EvtSelBefore_Theta("h2_EvtSelBefore_Theta", "h2_EvtSelBefore_Theta", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
-   TH2D h2_EvtSelBefore_Z("h2_EvtSelBefore_Z", "h2_EvtSelBefore_Z", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
-   TH2D h2_EvtSel_Theta("h2_EvtSel_Theta", "h2_EvtSel_Theta", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
-   TH2D h2_EvtSel_Z("h2_EvtSel_Z", "h2_EvtSel_Z", 2 * BinCount, 0, 2 * BinCount, EnergyBins.size()-1, EnergyBins.data());
-
-   // 1D histograms
-   TH1D h1_EvtSel_Z("h1_EvtSel_Z", "h1_EvtSel_Z", 2 * BinCount, 0, 2 * BinCount); 
-   TH1D h1_EvtSelBefore_Z("h1_EvtSelBefore_Z", "h1_EvtSelBefore_Z", 2 * BinCount, 0, 2 * BinCount); 
-   TH1D h1_EvtSel_Theta("h1_EvtSel_Theta", "h1_EvtSel_Theta", 2 * BinCount, 0, 2 * BinCount); 
-   TH1D h1_EvtSelBefore_Theta("h1_EvtSelBefore_Theta", "h1_EvtSelBefore_Theta", 2 * BinCount, 0, 2 * BinCount); 
-
-   // corrected 1D histograms
-   TH1D h1_EvtSelCorrected_Z("h1_EvtSelCorrected_Z", "h1_EvtSelCorrected_Z", 2 * BinCount, 0, 2 * BinCount); 
-   TH1D h1_EvtSelCorrected_Theta("h1_EvtSelCorrected_Theta", "h1_EvtSelCorrected_Theta", 2 * BinCount, 0, 2 * BinCount); 
-
-   //------------------------------------
-   // define the event selection efficiency correction factor
-   //------------------------------------
-   EffCorrFactor EvtSelEffCorrFactor;
-   if (!filesystem::exists(EvtSelEffFileName.c_str())) MakeEvtSelEffCorrFactor = true;
-   
-   if (MakeEvtSelEffCorrFactor)
+   h1_Projected2DUnfolding_Z.Scale(1.0/nEv2); 
+   h1_MCGen1D_Z.Scale(1.0/nEv2);
+   h1_Projected2DUnfolding_Theta.Scale(1.0/nEv2);
+   h1_MCGen1D_Theta.Scale(1.0/nEv2);
+   if (!MakeUnfoldingBinCorrFactor)
    {
-      printf("[INFO] produce event selection efficiency correction factor (%s), EvtSelEffArgName=%s\n", EvtSelEffFileName.c_str(), EvtSelEffArgName.c_str());
-   } else {
-      printf("[INFO] applying event selection efficiency correction factor (%s), EvtSelEffArgName=%s\n", EvtSelEffFileName.c_str(), EvtSelEffArgName.c_str());
-      EvtSelEffCorrFactor.init(EvtSelEffFileName.c_str(), EvtSelEffArgName.c_str());
+      h1_UnfoldingBinReweighted_Z.Scale(1.0/nEv2);
+      h1_UnfoldingBinReweighted_Theta.Scale(1.0/nEv2);
    }
 
-   // -------------------------------------
-   // loop over the tree after event selections
-   // -------------------------------------
-   int EntryCount = MGen.GetEntries();
-   for(int iE = 0; iE < EntryCount; iE++)
-   {
-      MGen.GetEntry(iE);
-
-      // fill the four vector
-      vector<FourVector> PGen;
-      for(int i = 0; i < MGen.nParticle; i++){
-        // charged particle selection 
-       if(MGen.charge[i] == 0) continue;
-       if(MGen.highPurity[i] == false) continue;
-         PGen.push_back(MGen.P[i]);
-      } // end loop over the particles 
-
-
-      // now calculate and fill the EECs
-      for(int i = 0; i < PGen.size(); i++)
-      {
-        for(int j = i+1; j < PGen.size();j++)
-        {
-            FourVector Gen1 = PGen.at(i);
-            FourVector Gen2 = PGen.at(j);
-
-            // get the proper bins
-            int BinThetaGen  = FindBin(GetAngle(Gen1,Gen2), 2 * BinCount, Bins);
-            // int BinEnergyGen = FindBin(Gen1[0]*Gen2[0]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
-            double zGen = (1-cos(GetAngle(Gen1,Gen2)))/2; 
-            int BinZGen = FindBin(zGen, 2*BinCount, zBins); 
-
-            // calculate the EEC
-            double EEC =  Gen1[0]*Gen2[0]/(TotalE*TotalE); 
-            
-            // fill the histograms
-            h2_EvtSel_Theta.Fill(BinThetaGen, EEC, EEC); 
-            h2_EvtSel_Z.Fill(BinZGen, EEC, EEC); 
-            h1_EvtSel_Z.Fill(BinZGen, EEC); 
-            h1_EvtSel_Theta.Fill(BinThetaGen, EEC);
-            if (!MakeEvtSelEffCorrFactor)
-            {
-               double efficiency = EvtSelEffCorrFactor.efficiency((EvtSelEffArgName=="z")? BinZGen: BinThetaGen,
-                                                                    EEC);
-               // printf("argBin: %d, z: %.3f, eff: %.3f \n", BinZGen, zGen, efficiency);
-               // printf("argBin: %d, normEEBin:%d, z: %.3f, normEE: %.3f, eff: %.3f \n", BinZGen, BinEnergyGen, zGen, EEC, efficiency);
-               h1_EvtSelCorrected_Z.Fill(BinZGen, EEC/efficiency); 
-               h1_EvtSelCorrected_Theta.Fill(BinThetaGen, EEC/efficiency);
-            }
-         }
-      }
-   } // end loop over the number of events'
-
-   // -------------------------------------
-   // loop over the tree before event selection
-   // -------------------------------------
-   int EntryCountBefore = MGenBefore.GetEntries();
-   for(int iE = 0; iE < EntryCountBefore; iE++)
-   {
-      MGenBefore.GetEntry(iE);
-      // fill the four vector
-      vector<FourVector> PGenBefore;
-      for(int i = 0; i < MGenBefore.nParticle; i++){
-        // charged particle selection 
-       if(MGenBefore.charge[i] == 0) continue;
-       if(MGenBefore.highPurity[i] == false) continue;
-         PGenBefore.push_back(MGenBefore.P[i]);
-      } // end loop over the particles 
-
-      // now calculate and fill the EECs
-      for(int i = 0; i < PGenBefore.size(); i++){
-        for(int j = i+1; j < PGenBefore.size();j++){
-            FourVector Gen1 = PGenBefore.at(i);
-            FourVector Gen2 = PGenBefore.at(j);
-
-            // get the proper bins
-            int BinThetaGen  = FindBin(GetAngle(Gen1,Gen2), 2 * BinCount, Bins);
-            // int BinEnergyGen = FindBin(Gen1[0]*Gen2[0]/(TotalE*TotalE), EnergyBinCount, EnergyBins);
-            double zGen = (1-cos(GetAngle(Gen1,Gen2)))/2; 
-            int BinZGen = FindBin(zGen, 2*BinCount, zBins); 
-
-            // calculate the EEC
-            double EEC =  Gen1[0]*Gen2[0]/(TotalE*TotalE); 
-            
-            // fill the histograms
-            h2_EvtSelBefore_Theta.Fill(BinThetaGen, EEC, EEC); 
-            h2_EvtSelBefore_Z.Fill(BinZGen, EEC, EEC); 
-            h1_EvtSelBefore_Z.Fill(BinZGen, EEC); 
-            h1_EvtSelBefore_Theta.Fill(BinThetaGen, EEC);
-         }
-      }
-   } // end loop over the number of events
-   // EEC is per-event so scale by the event number
-   printf( "h1_EvtSel_Z.GetEntries(): %.3f, EntryCount: %d, h1_EvtSelBefore_Z.GetEntries(): %.3f, EntryCountBefore: %d\n", 
-            h1_EvtSel_Z.GetEntries(), EntryCount,
-            h1_EvtSelBefore_Z.GetEntries(), EntryCountBefore );
-   h1_EvtSel_Z.Scale(1.0/EntryCount); 
-   h1_EvtSelBefore_Z.Scale(1.0/EntryCountBefore);
-   h1_EvtSel_Theta.Scale(1.0/EntryCount);
-   h1_EvtSelBefore_Theta.Scale(1.0/EntryCountBefore);
-   h2_EvtSel_Z.Scale(1.0/EntryCount); 
-   h2_EvtSelBefore_Z.Scale(1.0/EntryCountBefore);
-   h2_EvtSel_Theta.Scale(1.0/EntryCount);
-   h2_EvtSelBefore_Theta.Scale(1.0/EntryCountBefore);
-   if (!MakeEvtSelEffCorrFactor)
-   {
-      h1_EvtSelCorrected_Z.Scale(1.0/EntryCount);
-      h1_EvtSelCorrected_Theta.Scale(1.0/EntryCount);
-   }
 
    // divide by the bin width
-   DivideByBin(h1_EvtSel_Z, zBins);
-   DivideByBin(h1_EvtSelBefore_Z, zBins);
-   DivideByBin(h1_EvtSel_Theta, Bins);
-   DivideByBin(h1_EvtSelBefore_Theta, Bins);
-   if (!MakeEvtSelEffCorrFactor)
+   DivideByBin(h1_Projected2DUnfolding_Z, zBins);
+   DivideByBin(h1_MCGen1D_Z, zBins);
+   DivideByBin(h1_Projected2DUnfolding_Theta, Bins);
+   DivideByBin(h1_MCGen1D_Theta, Bins);
+   if (!MakeUnfoldingBinCorrFactor)
    {
-      DivideByBin(h1_EvtSelCorrected_Z,zBins);
-      DivideByBin(h1_EvtSelCorrected_Theta,Bins);
+      DivideByBin(h1_UnfoldingBinReweighted_Z, zBins);
+      DivideByBin(h1_UnfoldingBinReweighted_Theta, Bins);
    }
+
 
    // set the style for the plots
-   h1_EvtSel_Z.SetMarkerColor(Colors[2]);
-   h1_EvtSelBefore_Z.SetMarkerColor(Colors[3]);
-   h1_EvtSel_Theta.SetMarkerColor(Colors[2]);
-   h1_EvtSelBefore_Theta.SetMarkerColor(Colors[3]);
-   h1_EvtSel_Z.SetLineColor(Colors[2]);
-   h1_EvtSelBefore_Z.SetLineColor(Colors[3]);
-   h1_EvtSel_Theta.SetLineColor(Colors[2]);
-   h1_EvtSelBefore_Theta.SetLineColor(Colors[3]);
-   h1_EvtSel_Z.SetMarkerStyle(20);
-   h1_EvtSelBefore_Z.SetMarkerStyle(20);
-   h1_EvtSel_Theta.SetMarkerStyle(20);
-   h1_EvtSelBefore_Theta.SetMarkerStyle(20);
-   h1_EvtSel_Z.SetLineWidth(2);
-   h1_EvtSelBefore_Z.SetLineWidth(2);
-   h1_EvtSel_Theta.SetLineWidth(2);
-   h1_EvtSelBefore_Theta.SetLineWidth(2);
-   if (!MakeEvtSelEffCorrFactor)
+   h1_Projected2DUnfolding_Z.SetMarkerColor(Colors[2]);
+   h1_MCGen1D_Z.SetMarkerColor(Colors[3]);
+   h1_Projected2DUnfolding_Theta.SetMarkerColor(Colors[2]);
+   h1_MCGen1D_Theta.SetMarkerColor(Colors[3]);
+   h1_Projected2DUnfolding_Z.SetLineColor(Colors[2]);
+   h1_MCGen1D_Z.SetLineColor(Colors[3]);
+   h1_Projected2DUnfolding_Theta.SetLineColor(Colors[2]);
+   h1_MCGen1D_Theta.SetLineColor(Colors[3]);
+   h1_Projected2DUnfolding_Z.SetMarkerStyle(20);
+   h1_MCGen1D_Z.SetMarkerStyle(20);
+   h1_Projected2DUnfolding_Theta.SetMarkerStyle(20);
+   h1_MCGen1D_Theta.SetMarkerStyle(20);
+   h1_Projected2DUnfolding_Z.SetLineWidth(2);
+   h1_MCGen1D_Z.SetLineWidth(2);
+   h1_Projected2DUnfolding_Theta.SetLineWidth(2);
+   h1_MCGen1D_Theta.SetLineWidth(2);
+   if (!MakeUnfoldingBinCorrFactor)
    {
-      h1_EvtSelCorrected_Z.SetMarkerColor(Colors[4]);
-      h1_EvtSelCorrected_Z.SetLineColor(Colors[4]);
-      h1_EvtSelCorrected_Z.SetMarkerStyle(20);
-      h1_EvtSelCorrected_Z.SetLineWidth(2);
-      h1_EvtSelCorrected_Theta.SetMarkerColor(Colors[4]);
-      h1_EvtSelCorrected_Theta.SetLineColor(Colors[4]);
-      h1_EvtSelCorrected_Theta.SetMarkerStyle(20);
-      h1_EvtSelCorrected_Theta.SetLineWidth(2);
+      h1_UnfoldingBinReweighted_Z.SetMarkerColor(Colors[4]);
+      h1_UnfoldingBinReweighted_Z.SetLineColor(Colors[4]);
+      h1_UnfoldingBinReweighted_Z.SetMarkerStyle(20);
+      h1_UnfoldingBinReweighted_Z.SetLineWidth(2);
+      h1_UnfoldingBinReweighted_Theta.SetMarkerColor(Colors[4]);
+      h1_UnfoldingBinReweighted_Theta.SetLineColor(Colors[4]);
+      h1_UnfoldingBinReweighted_Theta.SetMarkerStyle(20);
+      h1_UnfoldingBinReweighted_Theta.SetLineWidth(2);
 
    }
 
-   if (!MakeEvtSelEffCorrFactor)
+   if (!MakeUnfoldingBinCorrFactor)
    {
-      std::vector<TH1D> hists = {h1_EvtSelBefore_Z, h1_EvtSel_Z, h1_EvtSelCorrected_Z}; 
-      std::vector<TH1D> hists_theta = {h1_EvtSelBefore_Theta, h1_EvtSel_Theta, h1_EvtSelCorrected_Theta};
+      std::vector<TH1D> hists = {h1_MCGen1D_Z, h1_Projected2DUnfolding_Z, h1_UnfoldingBinReweighted_Z}; 
+      std::vector<TH1D> hists_theta = {h1_MCGen1D_Theta, h1_Projected2DUnfolding_Theta, h1_UnfoldingBinReweighted_Theta};
 
       system("mkdir -p plot/");
-      string plotPrefix(EvtSelEffFileName);
+      string plotPrefix(UnfoldingBinCorrFileName);
       plotPrefix.replace(plotPrefix.find(".root"), 5, "");
-      MakeCanvasZ(hists, {"Before Evt. Sel.", "After Evt. Sel.", "Evt. Sel. Corrected"}, 
+      MakeCanvasZ(hists, {"MCGen 1D", "Projected 2D unfolding", "Projected 2D unfolding + bin reweighted"}, 
                   Form("plot/%s_Closure", plotPrefix.c_str()), "#it{z} = (1- cos(#theta))/2", "#frac{1}{#it{N}_{event}}#frac{d(Sum E_{i}E_{j}/E^{2})}{d#it{z}}",1e-3,1e3, true, true);
-      MakeCanvas(hists_theta, {"Before Evt. Sel.", "After Evt. Sel.", "Evt. Sel. Corrected"},
+      MakeCanvas(hists_theta, {"MCGen 1D", "Projected 2D unfolding", "Projected 2D unfolding + bin reweighted"},
                   Form("plot/%s_Theta_Closure", plotPrefix.c_str()),"#theta", "#frac{1}{#it{N}_{event}}#frac{d(Sum E_{i}E_{j}/E^{2})}{d#it{#theta}}",1e-3, 2e0, true, true);
    } 
    else 
    {
-      std::vector<TH1D> hists = {h1_EvtSelBefore_Z, h1_EvtSel_Z}; 
-      std::vector<TH1D> hists_theta = {h1_EvtSelBefore_Theta, h1_EvtSel_Theta};
+      std::vector<TH1D> hists = {h1_MCGen1D_Z, h1_Projected2DUnfolding_Z}; 
+      std::vector<TH1D> hists_theta = {h1_MCGen1D_Theta, h1_Projected2DUnfolding_Theta};
 
       system("mkdir -p plot/");
-      string plotPrefix(EvtSelEffFileName);
+      string plotPrefix(UnfoldingBinCorrFileName);
       plotPrefix.replace(plotPrefix.find(".root"), 5, "");
-      MakeCanvasZ(hists, {"Before Evt. Sel.", "After Evt. Sel."}, 
-                  Form("plot/%s_EvtSel", plotPrefix.c_str()), "#it{z} = (1- cos(#theta))/2", "#frac{1}{#it{N}_{event}}#frac{d(Sum E_{i}E_{j}/E^{2})}{d#it{z}}",1e-3,1e3, true, true);
-      MakeCanvas(hists_theta, {"Before Evt. Sel.", "After Evt. Sel."},
-                  Form("plot/%s_EvtSel_Theta", plotPrefix.c_str()),"#theta", "#frac{1}{#it{N}_{event}}#frac{d(Sum E_{i}E_{j}/E^{2})}{d#it{#theta}}",1e-3, 2e0, true, true);
+      MakeCanvasZ(hists, {"MCGen 1D", "Projected 2D unfolding"}, 
+                  Form("plot/%s_UnfoldingBinCorr", plotPrefix.c_str()), "#it{z} = (1- cos(#theta))/2", "#frac{1}{#it{N}_{event}}#frac{d(Sum E_{i}E_{j}/E^{2})}{d#it{z}}",1e-3,1e3, true, true);
+      MakeCanvas(hists_theta, {"MCGen 1D", "Projected 2D unfolding"},
+                  Form("plot/%s_UnfoldingBinCorr_Theta", plotPrefix.c_str()),"#theta", "#frac{1}{#it{N}_{event}}#frac{d(Sum E_{i}E_{j}/E^{2})}{d#it{#theta}}",1e-3, 2e0, true, true);
    }
 
-   // now handle the 2D plots
-
    // write to the output file
-   if (MakeEvtSelEffCorrFactor)
+   if (MakeUnfoldingBinCorrFactor)
    {
-      TFile OutputFile(EvtSelEffFileName.c_str(), "RECREATE");
-      EvtSelEffCorrFactor.write(OutputFile, "theta", &h1_EvtSel_Theta, &h1_EvtSelBefore_Theta);
-      EvtSelEffCorrFactor.write(OutputFile, "z", &h1_EvtSel_Z, &h1_EvtSelBefore_Z);
-      EvtSelEffCorrFactor.write(OutputFile, "theta", &h2_EvtSel_Theta, &h2_EvtSelBefore_Theta);
-      EvtSelEffCorrFactor.write(OutputFile, "z", &h2_EvtSel_Z, &h2_EvtSelBefore_Z);
+      TFile OutputFile(UnfoldingBinCorrFileName.c_str(), "RECREATE");
+      UnfoldingBinCorrFactor.write(OutputFile, "theta", &h1_Projected2DUnfolding_Theta, &h1_MCGen1D_Theta);
+      UnfoldingBinCorrFactor.write(OutputFile, "z", &h1_Projected2DUnfolding_Z, &h1_MCGen1D_Z);
 
       OutputFile.Close();
    }
@@ -521,7 +403,7 @@ void MakeCanvasZ(vector<TH1D>& Histograms, vector<string> Labels, string Output,
    Latex.SetTextAngle(90);
    Latex.SetTextColor(kBlack);
    if(DoRatio)
-      Latex.DrawLatex(MarginL * 0.3, MarginB + PadRHeight * 0.5, "Event Selection Eff.");
+      Latex.DrawLatex(MarginL * 0.3, MarginB + PadRHeight * 0.5, "Ratio");
    Latex.DrawLatex(MarginL * 0.3, MarginB + PadRHeight + PadHeight * 0.5, Y.c_str());
 
    Latex.SetTextAlign(11);


### PR DESCRIPTION
### Change log
- [mod] update the `EnergyBin` (from interger index bin to normal double bin) for the evt.-sel. and the matching efficiency correction factors, which need to be same histogram bin definition as the unfolding 2D histogram definition, if the correction is via a matrix multiplication of the histogram and the efficiency factors
- [new] `EffCorrFactor::applyEffCorrOnHisto`: doing the correction via a matrix multiplication of the histogram and the efficiency factors
- [new] UnfoldingBinningCorrection with the 1D `EffCorrFactor`

### Notes
- The statistical error propagation of the matrix-multiplication based correction is assuming the statistical uncertainties of the uncorrected distribution (e.g. EEC(z, EiEj/E^2) ) and the correction factor (e.g. epsilon(z, EiEj/E^2) ) are uncorrelated. [[source]](https://github.com/FHead/PhysicsEEJetEEC/compare/main...janice-cat:matchingEffCorr?expand=1#diff-1724a553f252bab3b63cd360e385702f018007a86b53ce73a5233ba0cfd2d219R119-R126)
- Unfolding Binning Correction
   - `UnfoldingBinningCorrection/`:  https://www.dropbox.com/scl/fo/p07l2bfn4epdb80wk38py/AByYE_u04yqg758GLdMYiVQ?rlkey=dtddvmuqywd1j0ntlkqjgmwf8&dl=0
   - Closure test ( corrected by `unfoldingBinCorr(z)` ): `UnfoldingBinCorr_with_z_Closure.pdf`, `UnfoldingBinCorr_with_theta_Theta_Closure.pdf`