### PR TITLE
Set particle 4 vector with x y z (more precise)

### DIFF
--- a/CommonCode/include/TauHelperFunctions3.h
+++ b/CommonCode/include/TauHelperFunctions3.h
@@ -67,6 +67,7 @@ public:
    FourVector(double p[4]);
    FourVector(double e, double px, double py, double pz);
    ~FourVector();
+   void SetXYZMass(double x, double y, double z, double mass = 0);
    void SetPtEtaPhi(double pt, double eta, double phi);   // massless
    void SetPtEtaPhiMass(double pt, double eta, double phi, double mass = 0);
    void SetPtYPhi(double pt, double y, double phi);   // massless

--- a/CommonCode/source/Messenger.cpp
+++ b/CommonCode/source/Messenger.cpp
@@ -550,7 +550,7 @@ bool ParticleTreeMessenger::GetEntry(int iEntry)
 
    P.resize(nParticle);
    for(int i = 0; i < nParticle; i++)
-      P[i].SetPtEtaPhiMass(pt[i], eta[i], phi[i], mass[i]);
+      P[i].SetXYZMass(px[i], py[i], pz[i], mass[i]);
 
    return true;
 }

--- a/CommonCode/source/TauHelperFunctions3.cpp
+++ b/CommonCode/source/TauHelperFunctions3.cpp
@@ -62,6 +62,17 @@ void FourVector::SetPtEtaPhi(double pt, double eta, double phi)
    SetPtEtaPhiMass(pt, eta, phi, 0);
 }
 //----------------------------------------------------------------------------
+void FourVector::SetXYZMass(double x, double y, double z, double mass)
+{
+   P[1] = x;
+   P[2] = y;
+   P[3] = z;
+
+   P[0] = sqrt(mass * mass + SpatialDot(*this));
+
+   CalculateInnerQuantities();
+}
+//----------------------------------------------------------------------------
 void FourVector::SetPtEtaPhiMass(double pt, double eta, double phi, double mass)
 {
    P[1] = pt * cos(phi);


### PR DESCRIPTION
This is a workaround. The current particle theta and phi branches are artificially truncated to 3 decimal places. This is unnecessary. If we start from px, py, pz and calculate the angles, we can recover better resolutions at higher pT.
For example, sigma_phi is approximately sigma_xy / pT, so we would see better resolution for pT > 1GeV.
The error of theta propagates less straightforwardly, hence the structures in the histogram.


@hjbossi This may have some impact on the small z EEC on both MC and data.

Using theta, phi:
![DeltaTheta_spherical](https://github.com/user-attachments/assets/ef227f04-e3a1-4292-9b1c-6f26dc5933be)
Using x,y,z:
![DeltaTheta_cartesian](https://github.com/user-attachments/assets/5633d1c3-5ccc-45ab-bb1f-ff163111c379)

Using theta, phi:
![DeltaPhi_spherical](https://github.com/user-attachments/assets/9207a7ca-cb2f-4b5c-b155-73f5fcb61d5a)
Using x,y,z:
![DeltaPhi_cartesian](https://github.com/user-attachments/assets/4ef657f5-9c20-4354-be7c-10896c1773c2)

